### PR TITLE
Fixed #8 Added instruction to install gcc-12 compiler

### DIFF
--- a/install_driver.sh
+++ b/install_driver.sh
@@ -6,7 +6,9 @@ echo ""
 
 echo "building"
 echo ""
-
+sudo apt-get install gcc-12 g++-12
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 20
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 20
 cd src/uvc
 COMPILER_VERSION=$(grep -o 'x86_64-linux-gnu-gcc-[0-9]*' /proc/version | head -n 1)
 if [[ -z $COMPILER_VERSION ]]; then


### PR DESCRIPTION
Fixed issue #8 

The error is happening because the older compiler is compiling the uvcvideo.c into uvcvideo.ko which is compatible for lower kernal version

> Now it is installing the required gcc compiler of version 12 and succesfully insatlling it and then it is compiling then everything go smooth