### PR TITLE
Correcting a syntax error

### DIFF
--- a/install_driver.sh
+++ b/install_driver.sh
@@ -75,7 +75,7 @@ echo ""
 echo "Report any issues on GitHub repo: https://github.com/PrabhatProxy/Quanta-HD-User-Facing-0x0408-0x4035_linux/issues"
 n
     make -C /lib/modules/$(uname -r)/build M=$(pwd)
-else
+then
     echo "$COMPILER_VERSION"
     echo ""
     make -C /lib/modules/$(uname -r)/build M=$(pwd) CC="$COMPILER_VERSION"


### PR DESCRIPTION
There is a small error in the install_driver.sh script at line number 78 it must be then instead of else which restricts the building of make file
I encountered the error when i was trying to install drivers for my acer aspire 7 but was not able to do so

On correcting the error the make file produced successfully, and the camera works properly
![Screenshot from 2025-02-18 03-47-00](https://github.com/user-attachments/assets/27d90457-b7c4-46bf-9bfe-2765007bd219)
